### PR TITLE
Fix build and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.abs
+*.DB
+*.DTA
+*.TX
+*.rom
+src/bin/

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = http://shamusworld.gotdns.org/git/rln
 [submodule "rmac"]
 	path = rmac
-	url = git@github.com:mwenge/rmac.git
+	url = https://github.com/mwenge/rmac.git

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ t2000.abs:
 	echo "515c0e0fcfe9a96d24c858968c3bad72  t2000.abs" | md5sum -c
 
 cartridge: t2000.abs
-	wine ./utils/filefix t2000.abs
+	wine ./utils/filefix.exe t2000.abs
 	./utils/CreateCart.py t2k.rom  src/incbin/romheader.bin T2000.TX src/incbin/paddingaftersamples.bin 
 	echo "602bc9953d3737b1ba52b2a0d9932f7c  t2k.rom" | md5sum -c
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The source code can be compiled into an executable that you can run in `virtual-
 
 ### Build Requirements
 ```sh
-sudo apt install build-essentials wine virtual-jaguar
+sudo apt install build-essentials wine dosbox virtual-jaguar
 ```
 
 ### Build the assembler toolchain


### PR DESCRIPTION
- Change rmac submodule to use HTTPS url, which causes less problems
- current wine requires the .exe extension to be specified
- current wine requires DOSBox to be installed for 16 bit programs (README change)
- add .gitignore file for build artifacts